### PR TITLE
feat: Switch chat model to use llm library

### DIFF
--- a/microllama/Dockerfile
+++ b/microllama/Dockerfile
@@ -4,12 +4,27 @@ EXPOSE 8080
 RUN pip install microllama
 WORKDIR /app
 COPY ./ /app
-# Remove these two lines if you don't want to
-# generate your index at container build time
+
+# --- Environment Variables --- 
+# Set API keys and configuration via environment variables.
+# OPENAI_API_KEY is *always* required for embeddings.
+# Set other keys (e.g., GEMINI_API_KEY) if using a different chat model.
+# Replace {openai_api_key} below or set the variable at runtime
 ENV OPENAI_API_KEY={openai_api_key}
+# Example for Gemini:
+# ENV GEMINI_API_KEY=your_gemini_key
+
 # Uncomment this line to enable debug mode
 # ENV DEBUG=True
-# Uncomment this line to switch model from gpt-3.5-turbo
-# ENV MODEL=gpt-4
+
+# Set the chat model ID used by llm. 
+# Ensure the corresponding llm plugin is installed (e.g., llm-openai is included by default).
+# ENV MODEL=gpt-4 
+# ENV MODEL=claude-3-opus # Requires pip install llm-anthropic
+# ENV MODEL=gemini-pro   # Requires pip install llm-gemini
+
+# Generate FAISS index at build time (requires OPENAI_API_KEY to be set above)
+# Remove this line if you prefer to index on first run or manually.
 RUN microllama index
+
 CMD ["microllama"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,9 @@ dependencies = [
     "fastapi",
     "uvicorn[standard]",
     "sse-starlette",
-    "typer"
+    "typer",
+    "llm",
+    "llm-openai"
 ]
 
 [project.urls]


### PR DESCRIPTION
- Adds llm and llm-openai as dependencies.

- Refactors answer() and streaming_answer() to use llm.get_model() and model.chat() instead of openai.ChatCompletion.

- Updates README, Dockerfile, and deploy_instructions() to reflect new dependencies, env var config (MODEL, API keys), and the continued need for OPENAI_API_KEY for embeddings.
